### PR TITLE
Add MQTT publishing of readings

### DIFF
--- a/cli/envsensor/main.go
+++ b/cli/envsensor/main.go
@@ -41,14 +41,16 @@ func main() {
 	}
 
 	// Program internals now
-	readingsChan := make(chan envsensor.Reading)
+	var readingChannels []chan envsensor.Reading
+	webChannel := make(chan envsensor.Reading)
+	readingChannels = append(readingChannels, webChannel)
 
 	// Start reading from sensor
 	sensor := envsensor.NewDHTSensor(config.SensorVersion, config.SensorPin, config.ProbeDelay)
-	go sensor.Start(readingsChan)
+	go sensor.Start(readingChannels)
 
 	// Serve readings, caching data up to a minute
 	port := fmt.Sprintf(":%d", int(config.WebPort))
 	server := envsensor.NewWebServer(port, config.CacheDuration)
-	server.Start(readingsChan)
+	server.Start(webChannel)
 }

--- a/cli/envsensor/main.go
+++ b/cli/envsensor/main.go
@@ -33,8 +33,9 @@ func main() {
 	flag.IntVar(&config.SensorPin, "sensor-pin", 17, "GPIO Pin (Physical number) to communicate to sensor via")
 	flag.IntVar(&config.SensorVersion, "sensor-version", 11, "Which DHT sensor to talk to. 11 or 22.")
 	flag.IntVar(&config.WebPort, "web-port", 8080, "Port for webserver to listen on")
-	flag.StringVar(&config.MQTTBroker, "mqtt-server", "", "MQTT server location (eg mqtt.local:1883)")
-	flag.StringVar(&config.Location, "location", "test", "Location to report stats from")
+	flag.StringVar(&config.MQTTBroker, "mqtt-broker", "", "MQTT server address (eg mqtt.local:1883)")
+	// We emit to the topic envsensor/status/LOCATION
+	flag.StringVar(&config.Location, "location", "test", "Location identifier for emitted readings")
 	flag.BoolVar(&config.Verbose, "verbose", false, "Verbose output")
 
 	flag.Parse()

--- a/internal/envsensor/mqtt_publisher.go
+++ b/internal/envsensor/mqtt_publisher.go
@@ -1,0 +1,73 @@
+package envsensor
+
+import (
+	"encoding/json"
+	"fmt"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	log "github.com/sirupsen/logrus"
+)
+
+type MQTTPublisher struct {
+	Broker   string
+	Location string
+}
+
+type MQTTReadingMessage struct {
+	Temperature float32 `json:"temperature"`
+	Humidity    float32 `json:"humidity"`
+}
+
+func NewMQTTPublisher(broker string, location string) MQTTPublisher {
+	return MQTTPublisher{
+		Broker:   broker,
+		Location: location,
+	}
+}
+
+func (p *MQTTPublisher) subscribeToReadings(readings <-chan Reading, client mqtt.Client) {
+	log.Debug("MQTTPublisher subscribing to readings")
+	for reading := range readings {
+		log.WithFields(log.Fields{
+			"reading": reading,
+		}).Info("MQTTPublisher received reading")
+
+		msgReading := MQTTReadingMessage{
+			Temperature: reading.Temperature,
+			Humidity:    reading.Humidity,
+		}
+
+		topic := fmt.Sprintf("envsensor/status/%s", p.Location)
+
+		payload, err := json.Marshal(msgReading)
+		if err != nil {
+			log.Fatal(err)
+		} else {
+			log.WithFields(log.Fields{
+				"topic":   topic,
+				"message": string(payload),
+			}).Debug("MQTTPublisher publishing")
+			client.Publish(topic, 0, false, string(payload)).Wait()
+		}
+	}
+	log.Debug("MQTTPublisher finished listening for readings")
+}
+
+func (p *MQTTPublisher) Start(readings <-chan Reading) {
+	log.WithFields(log.Fields{
+		"broker":   p.Broker,
+		"location": p.Location,
+	}).Info("MQTTPublisher publishing")
+
+	mqttParams := mqtt.NewClientOptions()
+	mqttParams.AddBroker("tcp://mqtt1:1883")
+	mqttParams.SetClientID("msub")
+
+	client := mqtt.NewClient(mqttParams)
+	client.Connect().Wait()
+
+	log.WithFields(log.Fields{
+		"broker": p.Broker,
+	}).Info("MQTTPublisher connected to broker")
+
+	p.subscribeToReadings(readings, client)
+}

--- a/internal/envsensor/web_server.go
+++ b/internal/envsensor/web_server.go
@@ -54,16 +54,16 @@ humidity {{.Humidity}}
 }
 
 func (h *WebServer) subscribeToReadings(readings <-chan Reading) {
-	log.Debug("Subscribing to readings")
+	log.Debug("WebServer subscribing to readings")
 	for reading := range readings {
 		log.WithFields(log.Fields{
 			"reading": reading,
-		}).Info("Received reading")
+		}).Info("WebServer received reading")
 
 		cachedReading := NewCachedReading(reading, h.cacheDuration)
 		h.currentValue = cachedReading
 	}
-	log.Debug("Finished listening for readings")
+	log.Debug("WebServer finished listening for readings")
 }
 
 func NewWebServer(listen string, cacheDuration time.Duration) WebServer {
@@ -82,6 +82,6 @@ func (h *WebServer) Start(readings <-chan Reading) {
 	http.HandleFunc("/", h.handleRoot)
 	http.HandleFunc("/metrics", h.handleMetrics)
 
-	log.Info("Waiting to answer all your requests on %s", h.listen)
+	log.Info("WebServer waiting to answer all your requests on ", h.listen)
 	http.ListenAndServe(h.listen, nil)
 }


### PR DESCRIPTION
Disabled by default.

Pass `--mqtt-broker HOST:PORT` to activate it. Location will default to test, override with `--location` for the appropriate identifier as to where your sensor is located.

Emits a JSON payload to the given topic. For example with a temp/humidity sensor connected and started with location `hall`:

* topic: `envsensor/status/hall`
* payload: `{"temperature":15.32,"humidity":53.2}`